### PR TITLE
Remove unused command from genload.sh

### DIFF
--- a/opsani/dev-trial/README.md
+++ b/opsani/dev-trial/README.md
@@ -7,10 +7,10 @@
 
 As described in the Opsani Dev Trial documentation, there are four parameters that need to be appropriately configured in the opsani-manifest.yaml:
 
-* NAMESPACE: should match the namespace against which the opsani servo is configured (default: bank-of-anthos-opsani)
-* DEPLOYMENT:  Is the Kubernetes deployment name that is to be optimized (default: frontend)
-* SERVICE: Is the Kubernetes service that points to the deployment application components (default: frontend)
-* CONTAINER: Is the name of the container in the Deployment spec that will be optimized (default: front)
+* NAMESPACE: The namespace against which the opsani servo is configured (default: bank-of-anthos-opsani)
+* DEPLOYMENT: The Kubernetes deployment name that is to be optimized (default: frontend)
+* CONTAINER: The name of the container in the Deployment spec that will be optimized (default: front)
+* SERVICE: The Kubernetes service that points to the deployment application components (default: frontend)
 
 A helper file that can be sourced in a `bash` environment (e.g. `source bank-of-anthos.source`) will create environment variables that will simplify the fine tuning of the Dev Trial environment to the Bank of Anthos application. It is recommended that any changes you may have made to the app, or the namespace, be captured in this file and then execute the following command (on a bash command line)
 

--- a/opsani/genload.sh
+++ b/opsani/genload.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-
+NAMESPACE=${NAMESPACE:-bank-of-anthos-opsani}
 DURATION=600
 echo ""
-echo "Change the load generator deployment scale every ${DURATION} seconds"
+echo "Change the load generator deployment scale every ${DURATION} seconds (in namespace ${NAMESPACE})"
 while [ true ]; do
     for item in 1 2 3 4 3 2 1 2 1 3 1 2 4 2 1 3 1 4 ; do
 	echo "generating load ${item}"
-        kubectl scale deployment loadgenerator --replicas ${item}
+        kubectl scale deployment loadgenerator --replicas ${item} -n ${NAMESPACE}
         sleep $(( ( RANDOM % ${DURATION} )  + 1 ))
     done
 done

--- a/opsani/genload.sh
+++ b/opsani/genload.sh
@@ -2,9 +2,6 @@
 
 DURATION=600
 echo ""
-echo "Update frontend service to point to envoy proxy for metrics capture"
-kubectl apply -f frontend-envoy-svc.yaml
-echo ""
 echo "Change the load generator deployment scale every ${DURATION} seconds"
 while [ true ]; do
     for item in 1 2 3 4 3 2 1 2 1 3 1 2 4 2 1 3 1 4 ; do


### PR DESCRIPTION
Fixes # .

Change summary:
- remove what appears to be command that is no longer needed


Remaining issues / concerns:
