### PR TITLE
fixed messaging in node check to reflect 8 instances and changed filt…

### DIFF
--- a/opsani/deploy.sh
+++ b/opsani/deploy.sh
@@ -13,15 +13,15 @@ else
   echo ""
 fi
 
-if [ "`kubectl get nodes | grep internal | wc -l`" -lt "8" ] ; then 
+if [ "`kubectl get nodes | grep Ready | wc -l`" -lt "8" ] ; then 
   echo "it appears that you do not have enough worker nodes to run this test"
   echo "currently there are `kubectl get nodes | grep internal | wc -l` nodes available"
-  echo "the minimum is 6 nodes (and it is recommended that they be AWS m5.xl or larger)"
+  echo "the minimum is 8 nodes (and it is recommended that they be AWS m5.xl or larger)"
   echo ""
   echo ""
   exit 1
 else
-  echo "It appears that you have at least 6 nodes available"
+  echo "It appears that you have at least 8 nodes available"
   echo ""
   echo ""
 fi


### PR DESCRIPTION
Change summary:
- Fixed messaging that still said that 6 nodes were required, while it is now checking for 8
- Fixed the grep we're using to get a node count to something not specific to AWS so that it will work with all providers

