### PR TITLE
exit on error applying manifests and update readme to ensure script i…

### DIFF
--- a/opsani/README.md
+++ b/opsani/README.md
@@ -17,7 +17,7 @@ This will support your efforts in deploying and validating this application.
 Run the `deploy.sh` script which will attempt to validate the pre-requisites, install any missing k8s service components, and install the Bank of Anthos application:
 
 ```sh
-./deploy.sh
+cd opsani && ./deploy.sh
 ```
 
 ## Install Bank of Anthos (Manually)

--- a/opsani/deploy.sh
+++ b/opsani/deploy.sh
@@ -89,6 +89,7 @@ kubectl apply -n ${NAMESPACE} -f ../kubernetes-manifests/
 if [ ! "echo $?" ]; then
   echo ""
   echo "a component may have failed to install.  Please look at the above output for errors"
+  exit 1
 else
   echo ""
   echo ""


### PR DESCRIPTION
Change summary:
- exits if there is an error applying manifests (otherwise it can fail to deploy and give you a success message anyway)
- updated opsani readme to explicitly add the directory you should be running deploy.sh from (it fails to find kubernetes-manifests dir if not run from opsani/)
