### PR TITLE
Update deploy.sh for envoy sidecar and otel instrumentation

### DIFF
--- a/kubernetes-manifests/frontend-hpa.yaml
+++ b/kubernetes-manifests/frontend-hpa.yaml
@@ -1,30 +1,30 @@
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: frontend
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: frontend
-  minReplicas: 1
-  maxReplicas: 20
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
-# apiVersion: autoscaling/v1
+# apiVersion: autoscaling/v2
 # kind: HorizontalPodAutoscaler
 # metadata:
 #   name: frontend
 # spec:
-#   maxReplicas: 20
-#   minReplicas: 1
-#   targetCPUUtilizationPercentage: 50
 #   scaleTargetRef:
 #     apiVersion: apps/v1
 #     kind: Deployment
 #     name: frontend
+#   minReplicas: 1
+#   maxReplicas: 20
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       target:
+#         type: Utilization
+#         averageUtilization: 50
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend
+spec:
+  maxReplicas: 20
+  minReplicas: 1
+  targetCPUUtilizationPercentage: 50
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend

--- a/kubernetes-manifests/kustomization.yaml
+++ b/kubernetes-manifests/kustomization.yaml
@@ -3,10 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- otel.yaml
+- config.yaml
+
 - accounts-db.yaml
 - balance-reader-hpa.yaml
 - balance-reader.yaml
-- config.yaml
 - contacts-hpa.yaml
 - contacts.yaml
 - frontend-hpa.yaml
@@ -19,3 +21,4 @@ resources:
 - transaction-history.yaml
 - userservice-hpa.yaml
 - userservice.yaml
+

--- a/opsani/README.md
+++ b/opsani/README.md
@@ -20,6 +20,18 @@ Run the `deploy.sh` script which will attempt to validate the pre-requisites, in
 cd opsani && ./deploy.sh
 ```
 
+To specify a namespace other than the default, set the NAMESPACE environment variable:
+
+```sh
+NAMESPACE=my-ns ./deploy.sh
+```
+
+To use envoy sidecars (useful for Prometheus scraping) set the ENVOY_SIDECAR environment variable:
+
+```sh
+ENVOY_SIDECAR=true ./deploy.sh
+```
+
 ## Install Bank of Anthos (Manually)
 
 The following commands will deploy the basic Bank-of-Anthos app, updated to use more realistic resources (requests/limits), and a loadgenerator deployment that should drive 3-5 frontend pods to run and scale up to ~10 pods over time (Currently ~ 1 hour).
@@ -52,7 +64,7 @@ kubectl config set-context `kubectl config get-contexts | awk '/^\*/ {print $2}'
 
 ### Ensure that the metrics service is installed and running
 
-Metrics are needed to run the HPA pod autoscaler, and are simple point in time cpu and memory data captured from 
+Metrics are needed to run the HPA pod autoscaler, and are simple point in time cpu and memory data captured from
 the kubelet service on each node. You need access to the kube-system namespace and the ability to create Cluster Roles and Cluster Role Bindings in order to apply this manifest from the Kubernetes metrics-sig:
 
 ```sh

--- a/opsani/deploy.sh
+++ b/opsani/deploy.sh
@@ -69,7 +69,13 @@ echo ""
 echo ""
 echo "Launch Bank-of-Anthos into ${NAMESPACE}"
 
-kubectl apply -n ${NAMESPACE} -k ../kubernetes-manifests/
+MANIFEST_DIR=../kubernetes-manifests
+if [ -n "$ENVOY_SIDECAR" ]; then
+  echo "Using envoy sidecar"
+  MANIFEST_DIR=../envoy
+fi
+
+kubectl kustomize  $MANIFEST_DIR --reorder none | kubectl apply -n ${NAMESPACE} -f -
 if [ ! "echo $?" ]; then
   echo ""
   echo "a component may have failed to install.  Please look at the above output for errors"


### PR DESCRIPTION
* Add ENVOY_SIDECAR option to deploy.sh to install envoy sidecars
* modify deploy.sh to install otel.yaml before pods are created, so they are OTEL instrumented
* Change frontent-hpa to use v1 HPA (backwards compatible with older k8s versions)

